### PR TITLE
Add `addRunAfterInstall` flag to .msi configuration

### DIFF
--- a/DSL_REFERENCE.md
+++ b/DSL_REFERENCE.md
@@ -169,6 +169,9 @@ MSI options go into an `msi` block:
 * `bitmapBanner`: Fie - a 493 x 58 pixels bmp image file used as a top
   banner on other dialogs
   (see [Wix UI Customization Guide](https://wixtoolset.org/docs/v3/wixui/wixui_customizations/#replacing-the-default-bitmaps))
+* `addRunAfterInstall`: Boolean (default: `false`) - add a dialog box 
+  "Run &lt;application&gt;" that, when clicked will start the installed
+  application on exiting the installer
 
 ## macOS options
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@ compose.tests.androidx.compiler.compatible.kotlin.version=1.6.10
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by PINPIT_GRADLE_PLUGIN_VERSION env var.
-deploy.version=0.10.0
+deploy.version=0.10.1

--- a/pinpit/src/main/kotlin/de/mobanisto/pinpit/desktop/application/dsl/PlatformSettings.kt
+++ b/pinpit/src/main/kotlin/de/mobanisto/pinpit/desktop/application/dsl/PlatformSettings.kt
@@ -187,4 +187,5 @@ abstract class MsiPlatformSettings : AbstractPlatformSettings() {
     var arch: String? = null
     val bitmapBanner: RegularFileProperty = objects.fileProperty()
     val bitmapDialog: RegularFileProperty = objects.fileProperty()
+    var addRunAfterInstall: Boolean = false
 }

--- a/pinpit/src/main/kotlin/de/mobanisto/pinpit/desktop/application/internal/configureJvmApplication.kt
+++ b/pinpit/src/main/kotlin/de/mobanisto/pinpit/desktop/application/internal/configureJvmApplication.kt
@@ -792,6 +792,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
         packageTask.iconFile.set(win.iconFile.orElse(unpackDefaultResources.flatMap { it.resources.windowsIcon }))
         packageTask.bitmapBanner.set(msi.bitmapBanner)
         packageTask.bitmapDialog.set(msi.bitmapDialog)
+        packageTask.addRunAfterInstall.set(msi.addRunAfterInstall)
     }
 }
 

--- a/pinpit/src/main/kotlin/de/mobanisto/pinpit/desktop/application/tasks/windows/GenerateProductWxs.kt
+++ b/pinpit/src/main/kotlin/de/mobanisto/pinpit/desktop/application/tasks/windows/GenerateProductWxs.kt
@@ -32,6 +32,7 @@ class GenerateProductWxs(
     private val shortcut: Boolean,
     private val menuFolder: String?,
     private val perUserInstall: Boolean,
+    private val addRunAfterInstall: Boolean,
 ) {
 
     fun execute() {
@@ -110,6 +111,21 @@ class GenerateProductWxs(
         product.createChild("Property", "WIXUI_INSTALLDIR") {
             setAttribute("Value", "INSTALLDIR")
         }
+
+        if (addRunAfterInstall) {
+            product.createChild("Property", "WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT") {
+                setAttribute("Value", "Run ${name}")
+            }
+            product.createChild("Property", "WIXUI_EXITDIALOGOPTIONALCHECKBOX") {
+                setAttribute("Value", "1")
+            }
+            product.createChild("CustomAction", "LaunchApplication") {
+                setAttribute("FileKey", mainExecutable.fileId)
+                setAttribute("ExeCommand", "")
+                setAttribute("Return", "asyncNoWait")
+            }
+        }
+
         product.createChild("UIRef", "InstallUI")
 
         product.createChild("Icon", iconId) {

--- a/pinpit/src/main/kotlin/de/mobanisto/pinpit/desktop/application/tasks/windows/PackageMsiTask.kt
+++ b/pinpit/src/main/kotlin/de/mobanisto/pinpit/desktop/application/tasks/windows/PackageMsiTask.kt
@@ -105,6 +105,10 @@ abstract class PackageMsiTask @Inject constructor(
     @get:Internal
     val appResourcesDir: DirectoryProperty = objects.directoryProperty()
 
+    @get:Input
+    @get:Optional
+    val addRunAfterInstall: Property<Boolean> = objects.notNullProperty()
+
     /**
      * Gradle runtime verification fails,
      * if InputDirectory is not null, but a directory does not exist.
@@ -157,6 +161,7 @@ abstract class PackageMsiTask @Inject constructor(
         val shortcut = shortcut.get()
         val menuGroup = menuGroup.orNull
         val perUserInstall = perUserInstall.get()
+        val addRunAfterInstall = addRunAfterInstall.get()
 
         val destinationWix = workingDir.asPath().resolve("wix")
         Files.createDirectories(destinationWix)
@@ -180,10 +185,13 @@ abstract class PackageMsiTask @Inject constructor(
             shortcut,
             menuGroup,
             perUserInstall,
+            addRunAfterInstall,
         ).execute()
 
         val outputInstallDir = destinationWix.resolve("InstallDir.wxs")
-        Thread.currentThread().contextClassLoader.getResourceAsStream("wix/InstallDir.wxs")?.use {
+        Thread.currentThread().contextClassLoader.getResourceAsStream(
+            if (addRunAfterInstall) "wix/InstallDir_run.wxs" else "wix/InstallDir.wxs"
+        )?.use {
             Files.copy(it, outputInstallDir)
         }
 

--- a/pinpit/src/main/resources/wix/InstallDir_run.wxs
+++ b/pinpit/src/main/resources/wix/InstallDir_run.wxs
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI Id="InstallUI">
+            <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
+            <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
+            <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
+
+            <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+            <Property Id="WixUI_Mode" Value="InstallDir" />
+
+            <DialogRef Id="BrowseDlg" />
+            <DialogRef Id="DiskCostDlg" />
+            <DialogRef Id="ErrorDlg" />
+            <DialogRef Id="FatalError" />
+            <DialogRef Id="FilesInUse" />
+            <DialogRef Id="MsiRMFilesInUse" />
+            <DialogRef Id="PrepareDlg" />
+            <DialogRef Id="ProgressDlg" />
+            <DialogRef Id="ResumeDlg" />
+            <DialogRef Id="UserExit" />
+
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3">1</Publish>
+            <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+
+            <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication" Order="998">
+                WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed
+            </Publish>
+            <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
+
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg">NOT Installed</Publish>
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
+
+            <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+            <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
+            <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
+
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="1">NOT Installed</Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
+
+            <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
+
+            <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+            <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+            <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
+
+            <Property Id="ARPNOMODIFY" Value="1" />
+        </UI>
+
+        <UIRef Id="WixUI_Common" />
+    </Fragment>
+</Wix>


### PR DESCRIPTION
This pull request adds a new flag `addRunAfterInstall` to the MSI installer configuration. When set to `true`, it will add a checkbox to the exit dialog of the installer that allows to run the installed application when the installer finishes.